### PR TITLE
Fixing demo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jupyter nbextension enable --py [--sys-prefix|--user|--system] powerbiclient
 ```
 For the list of features, refer [DOCUMENTATION](\DOCUMENTATION.md).
 
-## [Demo Notebook](\demo\demo.ipynb)
+## [Demo Notebook](demo/demo.ipynb)
 A Jupyter notebook that embeds a sample report.
 It demonstrates the complete flow of embedding and interacting with Power BI report i.e. embedding a Power BI report, setting report event handlers, get list of pages, get list of visuals, export and visualize visual data and apply filters.
 


### PR DESCRIPTION
Demo link currently 404's; see below:
<img width="500" alt="Screen Shot 2021-05-27 at 10 44 12" src="https://user-images.githubusercontent.com/6374067/119872615-8a73f280-bed8-11eb-995b-65da018ed105.png">
