### PR TITLE
Fixed broken link to DOCUMENTATION.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the nbextension:
 ```bash
 jupyter nbextension enable --py [--sys-prefix|--user|--system] powerbiclient
 ```
-For the list of features, refer [DOCUMENTATION](\DOCUMENTATION.md).
+For the list of features, refer [DOCUMENTATION](./DOCUMENTATION.md).
 
 ## [Demo Notebook](\demo\demo.ipynb)
 A Jupyter notebook that embeds a sample report.


### PR DESCRIPTION
The relative link to [DOCUMENTATION.md](https://github.com/microsoft/powerbi-jupyter/blob/main/DOCUMENTATION.md) on line 25 was prefixed with a backslash instead of a "dot-slash", so it was resolving to [https://github.com/microsoft/powerbi-jupyter/blob/main/%5CDOCUMENTATION.md](https://github.com/microsoft/powerbi-jupyter/blob/main/%5CDOCUMENTATION.md)

I changed it to use the proper "dot-slash" relative link prefix, like the link to [CONTRIBUTING.md](https://github.com/microsoft/powerbi-jupyter/blob/main/CONTRIBUTING.md) on line 48, which was already formatted and resolving correctly.